### PR TITLE
Change API base url

### DIFF
--- a/ytsclient/src/main/java/yts/YtsClient.java
+++ b/ytsclient/src/main/java/yts/YtsClient.java
@@ -87,7 +87,7 @@ public class YtsClient {
      */
     public static class Builder {
         private RestAdapter.LogLevel logLevel = RestAdapter.LogLevel.NONE;
-        private String apiUrl = "http://yts.to/api/v2";
+        private String apiUrl = "https://yts.ag/api/v2/";
 
         private boolean isCustomModulesInitialization = false;
         private boolean[] isModuleEnabled = new boolean[5];


### PR DESCRIPTION
http://yts.to/api/v2 Is not active for quite some time. There is new domain https://yts.ag/api/v2/