### PR TITLE
Add user-agent header to every http request.

### DIFF
--- a/ytsclient/src/main/java/yts/YtsClient.java
+++ b/ytsclient/src/main/java/yts/YtsClient.java
@@ -19,6 +19,7 @@ package yts;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 import retrofit.converter.GsonConverter;
 import yts.module.BookmarkModule;
@@ -26,6 +27,7 @@ import yts.module.CommentModule;
 import yts.module.MovieModule;
 import yts.module.RequestModule;
 import yts.module.UserModule;
+import yts.request.interceptor.UserAgentInterceptor;
 
 /**
  * Interface definition of the Yts API.
@@ -88,6 +90,7 @@ public class YtsClient {
     public static class Builder {
         private RestAdapter.LogLevel logLevel = RestAdapter.LogLevel.NONE;
         private String apiUrl = "http://yts.to/api/v2";
+        private RequestInterceptor requestInterceptor = new UserAgentInterceptor();
 
         private boolean isCustomModulesInitialization = false;
         private boolean[] isModuleEnabled = new boolean[5];
@@ -105,6 +108,14 @@ public class YtsClient {
                 throw new IllegalStateException("Url can not be null");
             }
             apiUrl = url;
+            return this;
+        }
+
+        public Builder withInterceptor(RequestInterceptor interceptor) {
+            if (interceptor == null) {
+                throw new IllegalArgumentException("Interceptor can not be null");
+            }
+            requestInterceptor = interceptor;
             return this;
         }
 
@@ -146,6 +157,7 @@ public class YtsClient {
             RestAdapter restAdapter = new RestAdapter.Builder()
                     .setEndpoint(apiUrl)
                     .setLogLevel(logLevel)
+                    .setRequestInterceptor(requestInterceptor)
                     .setConverter(new GsonConverter(gson))
                     .build();
 

--- a/ytsclient/src/main/java/yts/request/interceptor/UserAgentInterceptor.java
+++ b/ytsclient/src/main/java/yts/request/interceptor/UserAgentInterceptor.java
@@ -1,0 +1,13 @@
+package yts.request.interceptor;
+
+import retrofit.RequestInterceptor;
+
+public class UserAgentInterceptor implements RequestInterceptor {
+
+    private static final String USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.82 Safari/537.36";
+
+    @Override
+    public void intercept(RequestFacade request) {
+        request.addHeader("User-Agent", USER_AGENT);
+    }
+}


### PR DESCRIPTION
New api #4  is running behind CloudFlare which requires user-agent header to be sent. If it isn't, response is always 403 with following error message:

`The owner of this website (yts.ag) has banned your access based on your browser's signature`